### PR TITLE
Add support for a per-build config file (specified with PICO9918_CONFIG)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,34 @@ if (EXISTS ${picoVscode})
 endif()
 # ====================================================================================
 
+if (PICO9918_CONFIG)
+  message("Using PICO9918_CONFIG '${PICO9918_CONFIG}'")
+  include(${PICO9918_CONFIG})
+endif()
+
+#
+# Defaults if they're not set in the config file.
+#
+if (DEFINED PICO9918_RESTRICTED_HW_RPI_PICO)
+  #
+  # This is short-hand for "this is going to be run in a genuine
+  # Raspberry Pi Pico".  Force the board type to "pico" in this
+  # case, and disable the clock outputs (the Pico doesn't have
+  # enough GPIO pins for that).
+  #
+  message("PICO9918_RESTRICTED_HW_RPI_PICO specified in config file")
+  set(PICO9918_BOARD "pico")
+  set(PICO9918_NO_CLOCKS 1)
+endif()
+
+if (DEFINED PICO9918_BOARD)
+  message("Using PICO9918_BOARD '${PICO9918_BOARD}' from config file")
+else()
+  set(PICO9918_BOARD "pico9918_v04")
+endif()
+
 set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/src/boards )
-set(PICO_BOARD "pico9918_v04" CACHE STRING "Board type")
+set(PICO_BOARD ${PICO9918_BOARD} CACHE STRING "Board type")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,11 +7,45 @@ set(PICO9918_VERSION   "0.4.3")
 set(PICO9918_PCB_MAJOR_VER 0)
 set(PICO9918_PCB_MINOR_VER 4)
 
-set(PICO9918_SCANLINES 1)
+if (DEFINED PICO9918_SCANLINES)
+  message("Using PICO9918_SCANLINES '${PICO9918_SCANLINES}' from config file")
+else()
+  set(PICO9918_SCANLINES 1)
+endif()
 
 # SCART RGBs options
-set(PICO9918_SCART_RGBS 0)  # 1 for RGBs, 0 for VGA
-set(PICO9918_SCART_PAL  0)  # 1 for PAL 576i, 0 for NTSC 480i
+if (DEFINED PICO9918_SCART_RGBS)
+  message("Using PICO9918_SCART_RGBS '${PICO9918_SCART_RGBS}' from config file")
+else()
+  set(PICO9918_SCART_RGBS 0)  # 1 for RGBs, 0 for VGA
+endif()
+
+if (DEFINED PICO9918_SCART_PAL)
+  message("Using PICO9918_SCART_PAL '${PICO9918_SCART_PAL}' from config file")
+else()
+  set(PICO9918_SCART_PAL  0)  # 1 for PAL 576i, 0 for NTSC 480i
+endif()
+
+# options for other pico9918 hardware configurations
+if (DEFINED PICO9918_INT_ACTIVE_HIGH)
+  message("Using active-high interrupt output per config file")
+  add_definitions(-DPICO9918_INT_ACTIVE_HIGH)
+endif()
+
+if (DEFINED PICO9918_NO_CLOCKS)
+  message("Disabling clock outputs per config file")
+  add_definitions(-DPICO9918_NO_CLOCKS)
+endif()
+
+if (DEFINED PICO9918_SYNC_PINS_START)
+    message("Using PICO9918_SYNC_PINS_START '${PICO9918_SYNC_PINS_START}' from config file")
+  add_definitions(-DPICO9918_SYNC_PINS_START=${PICO9918_SYNC_PINS_START})
+endif()
+
+if (DEFINED PICO9918_RGB_PINS_START)
+  message("Using PICO9918_RGB_PINS_START '${PICO9918_RGB_PINS_START}' from config file")
+  add_definitions(-DPICO9918_RGB_PINS_START=${PICO9918_RGB_PINS_START})
+endif()
 
 # end compile-time options
 
@@ -37,7 +71,13 @@ endif()
 
 string(REPLACE "." "-" PICO9918_VERSION_STR "${PICO9918_VERSION}")
 
-set(PICO9918_BINARY_SUFFIX -pcb-v${PICO9918_PCB_MAJOR_VER}-${PICO9918_PCB_MINOR_VER}-${PICO9918_OUTPUT_STR}-build-${PICO9918_VERSION_STR})
+if (DEFINED PICO9918_PRODUCT)
+  message("Using PICO9918_PRODUCT '${PICO9918_PRODUCT}' from config file")
+else()
+  set(PICO9918_PRODUCT pcb-v${PICO9918_PCB_MAJOR_VER}-${PICO9918_PCB_MINOR_VER})
+endif()
+
+set(PICO9918_BINARY_SUFFIX -${PICO9918_PRODUCT}-${PICO9918_OUTPUT_STR}-build-${PICO9918_VERSION_STR})
 
 if (${PICO9918_SCANLINES})
   set(PICO9918_BINARY_SUFFIX ${PICO9918_BINARY_SUFFIX}-sl)

--- a/src/vga/vga.c
+++ b/src/vga/vga.c
@@ -48,11 +48,18 @@ int roundflt(float x)
     return (int)(x + 0.5f);
 }
 
-
+#ifdef PICO9918_SYNC_PINS_START
+#define SYNC_PINS_START	PICO9918_SYNC_PINS_START
+#else
 #define SYNC_PINS_START 0        // first sync pin gpio number
+#endif
 #define SYNC_PINS_COUNT 2        // number of sync pins (h and v)
 
+#ifdef PICO9918_RGB_PINS_START
+#define RGB_PINS_START	PICO9918_RGB_PINS_START
+#else
 #define RGB_PINS_START  2        // first rgb pin gpio number
+#endif
 #define RGB_PINS_COUNT 12        // number of rgb pins
 
 #define VGA_PIO         pio0_hw  // which pio are we using for vga?


### PR DESCRIPTION
Add support for a per-build config file (specified with PICO9918_CONFIG)
that parameterizes:
  - board type
  - product name
  - disabling clock outputs
  - interrupt polarity
  - RGB signal / color pin origins

...and consult the config file for these parameters that already existed:
  - scanlines yes/no
  - SCART yes/no/mode

Addresses issue #28.